### PR TITLE
feat: per-branch preview deploys + cleanup on branch delete (#7)

### DIFF
--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -286,12 +286,6 @@ jobs:
             exit 1
           fi
 
-          # Shared previews don't have per-branch projects to delete.
-          if [ "${PREVIEW_MODE:-shared}" != "branch" ]; then
-            echo "skip=yes" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           deleted_ref="${DELETED_REF:-}"
           if [ -z "$deleted_ref" ]; then
             echo "::error::Missing deleted branch name (github.event.ref)"

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -245,6 +245,30 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  # Shared helper used by both deploy + cleanup jobs to guarantee identical preview name derivation.
+  # This is intentionally stored once (as a function string) to avoid subtle divergence across steps.
+  BRANCH_PREVIEW_PROJECT_FN: |
+    compute_branch_preview_project() {
+      local ref="$1"
+      local base="$2"
+
+      local slug core hash prefix_len max_core
+      slug="$(printf '%s' "$ref" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+      [ -z "$slug" ] && slug="preview"
+
+      core="${slug}-${base}"
+      max_core=19
+      if [ ${#core} -gt $max_core ]; then
+        hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
+        prefix_len=$((max_core - 5)) # '-' + 4-char hash
+        core="${core:0:$prefix_len}-${hash}"
+        core="$(printf '%s' "$core" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
+      fi
+
+      printf '%s' "${core}-ubq-fi"
+    }
+
 jobs:
   cleanup:
     name: Cleanup Preview Project (branch delete)
@@ -258,14 +282,6 @@ jobs:
       DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
       DELETED_REF: ${{ github.event.ref }}
     steps:
-      - name: Validate preview_mode
-        run: |
-          set -euo pipefail
-          case "${PREVIEW_MODE}" in
-            shared|branch) ;;
-            *) echo "::error::Invalid preview_mode '${PREVIEW_MODE}'. Must be 'shared' or 'branch'."; exit 1 ;;
-          esac
-
       - name: Compute preview project name
         id: computed
         run: |
@@ -303,19 +319,8 @@ jobs:
 
           base="${project%-ubq-fi}"
 
-          slug="$(printf '%s' "$deleted_ref" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-          [ -z "$slug" ] && slug="preview"
-
-          core="${slug}-${base}"
-          max_core=19
-          if [ ${#core} -gt $max_core ]; then
-            hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
-            prefix_len=$((max_core - 5)) # '-' + 4-char hash
-            core="${core:0:$prefix_len}-${hash}"
-            core="$(printf '%s' "$core" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
-          fi
-
-          preview="${core}-ubq-fi"
+          eval "$BRANCH_PREVIEW_PROJECT_FN"
+          preview="$(compute_branch_preview_project "$deleted_ref" "$base")"
           echo "project=$preview" >> "$GITHUB_OUTPUT"
           echo "skip=no" >> "$GITHUB_OUTPUT"
 
@@ -564,7 +569,7 @@ jobs:
         id: target
         env:
           REF_NAME: ${{ github.ref_name }}
-          HEAD_REF: ${{ github.head_ref || '' }}
+          HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_EVENT: ${{ github.event.workflow_run.event || '' }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
@@ -597,6 +602,10 @@ jobs:
 
           preview="${PREVIEW_PROJECT:-}"
           ref_name="${REF_NAME:-}"
+          head_ref="${HEAD_REF:-}"
+          if [ -n "$head_ref" ]; then
+            ref_name="$head_ref"
+          fi
           if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
             ref_name="$HEAD_BRANCH"
           elif [ "$EVENT_NAME" = "pull_request" ] && [ -n "${HEAD_REF:-}" ]; then
@@ -608,19 +617,8 @@ jobs:
           if [ -z "$preview" ]; then
             if [ "${PREVIEW_MODE:-shared}" = "branch" ]; then
               # Per-branch preview project: <branch>-<base>-ubq-fi (clamped to 26 chars with hash)
-              slug="$(printf '%s' "$ref_name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-              [ -z "$slug" ] && slug="preview"
-
-              core="${slug}-${base}"
-              max_core=19
-              if [ ${#core} -gt $max_core ]; then
-                hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
-                prefix_len=$((max_core - 5)) # '-' + 4-char hash
-                core="${core:0:$prefix_len}-${hash}"
-                core="$(printf '%s' "$core" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
-              fi
-
-              preview="${core}-ubq-fi"
+              eval "$BRANCH_PREVIEW_PROJECT_FN"
+              preview="$(compute_branch_preview_project "$ref_name" "$base")"
             else
               # Shared preview project: p-<base>-ubq-fi (clamped)
               # Clamp base to keep preview <=26 with prefix/suffix: p- + base + -ubq-fi

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ""
+      preview_mode:
+        description: Preview deployment strategy. "shared" uses a single preview project for all branches (default). "branch" creates a per-branch preview project + router URL.
+        required: false
+        type: string
+        default: "shared"
       entrypoint:
         description: Entrypoint file passed to deployctl (relative to root)
         required: true
@@ -241,8 +246,112 @@ permissions:
   pull-requests: write
 
 jobs:
+  cleanup:
+    name: Cleanup Preview Project (branch delete)
+    if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' && inputs.preview_mode == 'branch' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      PROJECT: ${{ inputs.project }}
+      PREVIEW_PROJECT: ${{ inputs.preview_project }}
+      PREVIEW_MODE: ${{ inputs.preview_mode }}
+      DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+      DELETED_REF: ${{ github.event.ref }}
+    steps:
+      - name: Compute preview project name
+        id: computed
+        run: |
+          set -euo pipefail
+          if [ -z "${DENO_DEPLOY_TOKEN:-}" ]; then
+            echo "::error::DENO_DEPLOY_TOKEN is required for cleanup"
+            exit 1
+          fi
+
+          project="${PROJECT:-}"
+          if [ -z "$project" ]; then
+            # Fall back to repo name when the caller doesn't pass `project`.
+            repo="${GITHUB_REPOSITORY##*/}"
+            project="${repo}-ubq-fi"
+          fi
+
+          if [[ "$project" != *-ubq-fi ]]; then
+            echo "::error::Project name must end with '-ubq-fi'. Got: $project"
+            exit 1
+          fi
+
+          # Shared previews don't have per-branch projects to delete.
+          if [ "${PREVIEW_MODE:-shared}" != "branch" ]; then
+            echo "skip=yes" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          deleted_ref="${DELETED_REF:-}"
+          if [ -z "$deleted_ref" ]; then
+            echo "::error::Missing deleted branch name (github.event.ref)"
+            exit 1
+          fi
+
+          preview="${PREVIEW_PROJECT:-}"
+          if [ -n "$preview" ]; then
+            # Caller explicitly set a preview project; treat it as the cleanup target.
+            echo "project=$preview" >> "$GITHUB_OUTPUT"
+            echo "skip=no" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="${project%-ubq-fi}"
+
+          slug="$(printf '%s' "$deleted_ref" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+          [ -z "$slug" ] && slug="preview"
+
+          core="${slug}-${base}"
+          max_core=19
+          if [ ${#core} -gt $max_core ]; then
+            hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
+            prefix_len=$((max_core - 5)) # '-' + 4-char hash
+            core="${core:0:$prefix_len}-${hash}"
+            core="$(printf '%s' "$core" | sed -E 's/^-+//; s/-+$//')"
+          fi
+
+          preview="${core}-ubq-fi"
+          echo "project=$preview" >> "$GITHUB_OUTPUT"
+          echo "skip=no" >> "$GITHUB_OUTPUT"
+
+      - name: Delete preview project via Deno Deploy API
+        if: steps.computed.outputs.skip != 'yes'
+        env:
+          TARGET_PROJECT: ${{ steps.computed.outputs.project }}
+        run: |
+          set -euo pipefail
+          project="${TARGET_PROJECT:-}"
+          if [ -z "$project" ]; then
+            echo "::error::Target project was not resolved"
+            exit 1
+          fi
+
+          api_base="https://dash.deno.com/api/projects"
+          http_code="$(
+            curl -sS -o /dev/null -w "%{http_code}" \
+              -X DELETE \
+              -H "Authorization: Bearer $DENO_DEPLOY_TOKEN" \
+              -H "Accept: application/json" \
+              "$api_base/$project" || echo "000"
+          )"
+
+          if [ "$http_code" = "404" ]; then
+            echo "::warning::Preview project $project not found (already deleted?)"
+            exit 0
+          fi
+          if [ "$http_code" != "200" ] && [ "$http_code" != "204" ]; then
+            echo "::error::Failed to delete preview project $project (HTTP $http_code)"
+            exit 1
+          fi
+
+          echo "Deleted preview project: $project"
+
   deploy:
     name: Deno Deploy
+    if: ${{ github.event_name != 'delete' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     concurrency:
@@ -252,6 +361,7 @@ jobs:
       PROD_BRANCH: ${{ inputs.prod_branch != '' && inputs.prod_branch || github.event.repository.default_branch }}
       PROJECT: ${{ inputs.project }}
       PREVIEW_PROJECT: ${{ inputs.preview_project }}
+      PREVIEW_MODE: ${{ inputs.preview_mode }}
       ENTRYPOINT: ${{ inputs.entrypoint }}
       ROOT_DIR: ${{ inputs.root }}
       ARTIFACT_NAME: ${{ inputs.artifact_name }}
@@ -471,16 +581,41 @@ jobs:
             exit 1
           fi
 
+          base="${project%-ubq-fi}"
+
           preview="${PREVIEW_PROJECT:-}"
+          ref_name="${REF_NAME:-}"
+          if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
+            ref_name="$HEAD_BRANCH"
+          fi
+
           if [ -z "$preview" ]; then
-            base="${project%-ubq-fi}"
-            # Clamp base to keep preview <=26 with prefix/suffix: p- + base + -ubq-fi
-            if [ ${#base} -gt 17 ]; then
-              # 12 chars + dash + 4-char hash = 17
-              hash=$(printf '%s' "$base" | sha1sum | cut -c1-4)
-              base="${base:0:12}-${hash}"
+            if [ "${PREVIEW_MODE:-shared}" = "branch" ]; then
+              # Per-branch preview project: <branch>-<base>-ubq-fi (clamped to 26 chars with hash)
+              slug="$(printf '%s' "$ref_name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+              [ -z "$slug" ] && slug="preview"
+
+              core="${slug}-${base}"
+              max_core=19
+              if [ ${#core} -gt $max_core ]; then
+                hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
+                prefix_len=$((max_core - 5)) # '-' + 4-char hash
+                core="${core:0:$prefix_len}-${hash}"
+                core="$(printf '%s' "$core" | sed -E 's/^-+//; s/-+$//')"
+              fi
+
+              preview="${core}-ubq-fi"
+            else
+              # Shared preview project: p-<base>-ubq-fi (clamped)
+              # Clamp base to keep preview <=26 with prefix/suffix: p- + base + -ubq-fi
+              clamped="$base"
+              if [ ${#clamped} -gt 17 ]; then
+                # 12 chars + dash + 4-char hash = 17
+                hash="$(printf '%s' "$clamped" | sha1sum | cut -c1-4)"
+                clamped="${clamped:0:12}-${hash}"
+              fi
+              preview="p-${clamped}-ubq-fi"
             fi
-            preview="p-${base}-ubq-fi"
           fi
 
           if [ ${#preview} -gt 26 ]; then
@@ -490,11 +625,6 @@ jobs:
           if ! [[ "$preview" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
             echo "::error::Preview project name must be DNS-safe (lowercase letters, numbers, hyphens; no leading/trailing hyphen). Got: $preview"
             exit 1
-          fi
-
-          ref_name="${REF_NAME:-}"
-          if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
-            ref_name="$HEAD_BRANCH"
           fi
 
           mode="preview"
@@ -966,12 +1096,14 @@ jobs:
           MODE: ${{ steps.deploy.outputs.mode }}
           TARGET_PROJECT: ${{ steps.deploy.outputs.project }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url || '' }}
+          PREVIEW_MODE: ${{ env.PREVIEW_MODE }}
         run: |
           set -euo pipefail
           mode="${MODE:-}"
           target_project="${TARGET_PROJECT:-}"
           prod_project="${PROJECT:-}"
           deployment_url="${DEPLOYMENT_URL:-}"
+          preview_mode="${PREVIEW_MODE:-shared}"
 
           project_url="https://${target_project}.deno.dev"
           router_url=""
@@ -985,7 +1117,11 @@ jobs:
             if [ "$mode" = "production" ]; then
               router_url="https://${base}.ubq.fi"
             else
-              router_url="https://preview-${base}.ubq.fi"
+              if [ "$preview_mode" = "branch" ]; then
+                router_url="https://${target_project%-ubq-fi}.ubq.fi"
+              else
+                router_url="https://preview-${base}.ubq.fi"
+              fi
             fi
           fi
 

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -294,9 +294,10 @@ jobs:
 
           preview="${PREVIEW_PROJECT:-}"
           if [ -n "$preview" ]; then
-            # Caller explicitly set a preview project; treat it as the cleanup target.
-            echo "project=$preview" >> "$GITHUB_OUTPUT"
-            echo "skip=no" >> "$GITHUB_OUTPUT"
+            # In branch preview mode, an explicit preview_project is ambiguous (it may be shared across branches).
+            # Avoid deleting a potentially shared project when any branch is deleted.
+            echo "::warning::Skipping cleanup because preview_project was explicitly provided (not a derived per-branch project)"
+            echo "skip=yes" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -564,6 +564,7 @@ jobs:
         id: target
         env:
           REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref || '' }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_EVENT: ${{ github.event.workflow_run.event || '' }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
@@ -598,6 +599,10 @@ jobs:
           ref_name="${REF_NAME:-}"
           if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
             ref_name="$HEAD_BRANCH"
+          elif [ "$EVENT_NAME" = "pull_request" ] && [ -n "${HEAD_REF:-}" ]; then
+            # For pull_request events, github.ref_name is "<pr_number>/merge".
+            # Use github.head_ref to derive a stable per-branch preview project name.
+            ref_name="$HEAD_REF"
           fi
 
           if [ -z "$preview" ]; then

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -258,6 +258,14 @@ jobs:
       DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
       DELETED_REF: ${{ github.event.ref }}
     steps:
+      - name: Validate preview_mode
+        run: |
+          set -euo pipefail
+          case "${PREVIEW_MODE}" in
+            shared|branch) ;;
+            *) echo "::error::Invalid preview_mode '${PREVIEW_MODE}'. Must be 'shared' or 'branch'."; exit 1 ;;
+          esac
+
       - name: Compute preview project name
         id: computed
         run: |
@@ -269,9 +277,8 @@ jobs:
 
           project="${PROJECT:-}"
           if [ -z "$project" ]; then
-            # Fall back to repo name when the caller doesn't pass `project`.
-            repo="${GITHUB_REPOSITORY##*/}"
-            project="${repo}-ubq-fi"
+            echo "::error::Missing required input: project (must end with '-ubq-fi')"
+            exit 1
           fi
 
           if [[ "$project" != *-ubq-fi ]]; then
@@ -310,7 +317,7 @@ jobs:
             hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
             prefix_len=$((max_core - 5)) # '-' + 4-char hash
             core="${core:0:$prefix_len}-${hash}"
-            core="$(printf '%s' "$core" | sed -E 's/^-+//; s/-+$//')"
+            core="$(printf '%s' "$core" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
           fi
 
           preview="${core}-ubq-fi"
@@ -567,7 +574,16 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
         run: |
           set -euo pipefail
+          case "${PREVIEW_MODE}" in
+            shared|branch) ;;
+            *) echo "::error::Invalid preview_mode '${PREVIEW_MODE}'. Must be 'shared' or 'branch'."; exit 1 ;;
+          esac
+
           project="${PROJECT:-}"
+          if [ -z "$project" ]; then
+            echo "::error::Missing required input: project (must end with '-ubq-fi')"
+            exit 1
+          fi
           if [[ "$project" != *-ubq-fi ]]; then
             echo "::error::Project name must end with '-ubq-fi' to match router mapping. Got: $project"
             exit 1
@@ -601,7 +617,7 @@ jobs:
                 hash="$(printf '%s' "$core" | sha1sum | cut -c1-4)"
                 prefix_len=$((max_core - 5)) # '-' + 4-char hash
                 core="${core:0:$prefix_len}-${hash}"
-                core="$(printf '%s' "$core" | sed -E 's/^-+//; s/-+$//')"
+                core="$(printf '%s' "$core" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
               fi
 
               preview="${core}-ubq-fi"


### PR DESCRIPTION
Fixes #7

## What
- Add `preview_mode: shared|branch` (default: shared)
- When `preview_mode=branch`, derive preview project name from the branch (DNS-safe, clamped to 26 chars with short hash)
- For branch previews, compute router URL as `https://<derived>.ubq.fi` instead of `https://preview-<base>.ubq.fi`
- Add a cleanup job for branch delete events that deletes the derived preview project via Deno Deploy API

## Notes
- Backwards compatible: default behavior is unchanged unless `preview_mode` is set to `branch`
- Cleanup runs only when the caller triggers this reusable workflow from a `delete` event

## Testing
- `scripts/lint-actions.sh`
