### PR TITLE
fix: support branch preview project names

### DIFF
--- a/.github/workflows/deno-deploy-preview-cleanup.yml
+++ b/.github/workflows/deno-deploy-preview-cleanup.yml
@@ -1,0 +1,203 @@
+name: Reusable - Deno Deploy Preview Cleanup
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: Production Deno Deploy project name
+        required: true
+        type: string
+      ref_name:
+        description: Deleted branch ref name
+        required: true
+        type: string
+      preview_project:
+        description: Explicit preview project name to delete
+        required: false
+        type: string
+        default: ""
+      preview_strategy:
+        description: Preview naming strategy when preview_project is not provided (branch|shared)
+        required: false
+        type: string
+        default: branch
+      prod_branch:
+        description: Production branch name
+        required: false
+        type: string
+        default: ""
+    secrets:
+      DENO_DEPLOY_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete preview project
+    runs-on: ubuntu-22.04
+    env:
+      PROJECT: ${{ inputs.project }}
+      REF_NAME: ${{ inputs.ref_name }}
+      PREVIEW_PROJECT: ${{ inputs.preview_project }}
+      PREVIEW_STRATEGY: ${{ inputs.preview_strategy }}
+      PROD_BRANCH: ${{ inputs.prod_branch != '' && inputs.prod_branch || github.event.repository.default_branch }}
+      DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+    steps:
+      - name: Determine preview project
+        id: target
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            printf '%s' "$1" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
+          }
+
+          shorten_slug() {
+            value="$1"
+            max_len="$2"
+            [ ${#value} -le "$max_len" ] && {
+              printf '%s' "$value"
+              return 0
+            }
+            hash=$(printf '%s' "$value" | sha1sum | cut -c1-4)
+            head_len=$((max_len - 5))
+            printf '%s-%s' "${value:0:${head_len}}" "$hash"
+          }
+
+          branch_preview_name() {
+            project_name="$1"
+            ref_name="$2"
+
+            base="${project_name%-ubq-fi}"
+            if [ "$project_name" = "ubq-fi" ]; then
+              base="ubq"
+            fi
+
+            branch_slug="$(slugify "$ref_name")"
+            base_slug="$(slugify "$base")"
+            [ -n "$branch_slug" ] || branch_slug="preview"
+            [ -n "$base_slug" ] || base_slug="ubq"
+
+            suffix="-ubq-fi"
+            available=$((26 - ${#suffix}))
+            separator_len=1
+            min_branch_len=6
+            min_base_len=6
+
+            branch_len=${#branch_slug}
+            base_len=${#base_slug}
+            if [ $((branch_len + separator_len + base_len)) -gt "$available" ]; then
+              base_budget=$((available - separator_len - min_branch_len))
+              if [ "$base_budget" -lt "$min_base_len" ]; then
+                base_budget="$min_base_len"
+              fi
+              if [ "$base_budget" -gt "$base_len" ]; then
+                base_budget="$base_len"
+              fi
+
+              branch_budget=$((available - separator_len - base_budget))
+              if [ "$branch_budget" -lt "$min_branch_len" ]; then
+                branch_budget="$min_branch_len"
+                base_budget=$((available - separator_len - branch_budget))
+              fi
+
+              base_slug="$(shorten_slug "$base_slug" "$base_budget")"
+              branch_slug="$(shorten_slug "$branch_slug" "$branch_budget")"
+            fi
+
+            printf '%s-%s-ubq-fi\n' "$branch_slug" "$base_slug"
+          }
+
+          project="${PROJECT:-}"
+          if [ "$project" != "ubq-fi" ] && [[ "$project" != *-ubq-fi ]]; then
+            echo "::error::Project name must be 'ubq-fi' or end with '-ubq-fi'. Got: $project"
+            exit 1
+          fi
+          if ! [[ "$project" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+            echo "::error::Project name must be DNS-safe. Got: $project"
+            exit 1
+          fi
+
+          ref_name="${REF_NAME:-}"
+          if [ -z "$ref_name" ]; then
+            echo "::notice::Empty ref_name, skipping cleanup"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$ref_name" = "$PROD_BRANCH" ]; then
+            echo "::notice::Deleted ref matches production branch (${PROD_BRANCH}), skipping cleanup"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          target="${PREVIEW_PROJECT:-}"
+          strategy="${PREVIEW_STRATEGY:-branch}"
+          case "$strategy" in
+            branch|shared) ;;
+            *)
+              echo "::error::preview_strategy must be 'branch' or 'shared'. Got: $strategy"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$target" ]; then
+            if [ "$strategy" = "branch" ]; then
+              target="$(branch_preview_name "$project" "$ref_name")"
+            elif [ "$project" = "ubq-fi" ]; then
+              target="p-ubq-fi"
+            else
+              base="${project%-ubq-fi}"
+              if [ ${#base} -gt 17 ]; then
+                hash=$(printf '%s' "$base" | sha1sum | cut -c1-4)
+                base="${base:0:12}-${hash}"
+              fi
+              target="p-${base}-ubq-fi"
+            fi
+          fi
+
+          if [ "$target" = "$project" ]; then
+            echo "::error::Refusing to delete production project '${project}' via preview cleanup"
+            exit 1
+          fi
+          if [ ${#target} -gt 26 ]; then
+            echo "::error::Preview project name '${target}' exceeds 26 characters"
+            exit 1
+          fi
+          if ! [[ "$target" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+            echo "::error::Preview project name must be DNS-safe. Got: $target"
+            exit 1
+          fi
+
+          {
+            echo "skip=false"
+            echo "project=$target"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delete preview project
+        if: steps.target.outputs.skip != 'true'
+        env:
+          TARGET_PROJECT: ${{ steps.target.outputs.project }}
+        run: |
+          set -euo pipefail
+          api="https://dash.deno.com/api/projects/${TARGET_PROJECT}"
+          code=$(curl -sS -o /tmp/delete-preview-project.json -w "%{http_code}" -X DELETE \
+            -H "Authorization: Bearer ${DENO_DEPLOY_TOKEN}" \
+            "$api" || echo "000")
+
+          if [ "$code" = "404" ]; then
+            echo "Preview project ${TARGET_PROJECT} already removed"
+            exit 0
+          fi
+
+          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+            echo "::error::Failed to delete preview project ${TARGET_PROJECT} (HTTP ${code})"
+            cat /tmp/delete-preview-project.json || true
+            exit 1
+          fi
+
+          echo "Deleted preview project ${TARGET_PROJECT}"

--- a/.github/workflows/deno-deploy-preview-cleanup.yml
+++ b/.github/workflows/deno-deploy-preview-cleanup.yml
@@ -50,12 +50,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Normalize a branch or project segment into a DNS-safe slug.
           slugify() {
             printf '%s' "$1" \
               | tr '[:upper:]' '[:lower:]' \
               | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
           }
 
+          # Shorten an already-normalized slug while keeping a stable hash suffix.
           shorten_slug() {
             value="$1"
             max_len="$2"
@@ -68,6 +70,7 @@ jobs:
             printf '%s-%s' "${value:0:${head_len}}" "$hash"
           }
 
+          # Build the Deno Deploy preview project name for a branch and base project.
           branch_preview_name() {
             project_name="$1"
             ref_name="$2"

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -526,12 +526,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Normalize a branch or project segment into a DNS-safe slug.
           slugify() {
             printf '%s' "$1" \
               | tr '[:upper:]' '[:lower:]' \
               | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
           }
 
+          # Shorten an already-normalized slug while keeping a stable hash suffix.
           shorten_slug() {
             value="$1"
             max_len="$2"
@@ -544,6 +546,7 @@ jobs:
             printf '%s-%s' "${value:0:${head_len}}" "$hash"
           }
 
+          # Build the Deno Deploy preview project name for a branch and base project.
           branch_preview_name() {
             project_name="$1"
             ref_name="$2"

--- a/.github/workflows/deno-deploy-reusable.yml
+++ b/.github/workflows/deno-deploy-reusable.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ""
+      preview_strategy:
+        description: Preview naming strategy when preview_project is not provided (branch|shared)
+        required: false
+        type: string
+        default: branch
       entrypoint:
         description: Entrypoint file passed to Deno Deploy (relative to root)
         required: true
@@ -292,6 +297,7 @@ jobs:
       PROD_BRANCH: ${{ inputs.prod_branch != '' && inputs.prod_branch || github.event.repository.default_branch }}
       PROJECT: ${{ inputs.project }}
       PREVIEW_PROJECT: ${{ inputs.preview_project }}
+      PREVIEW_STRATEGY: ${{ inputs.preview_strategy }}
       ENTRYPOINT: ${{ inputs.entrypoint }}
       ROOT_DIR: ${{ inputs.root }}
       ARTIFACT_NAME: ${{ inputs.artifact_name }}
@@ -513,11 +519,75 @@ jobs:
         id: target
         env:
           REF_NAME: ${{ github.ref_name }}
+          HEAD_REF: ${{ github.head_ref || '' }}
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_EVENT: ${{ github.event.workflow_run.event || '' }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
         run: |
           set -euo pipefail
+
+          slugify() {
+            printf '%s' "$1" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
+          }
+
+          shorten_slug() {
+            value="$1"
+            max_len="$2"
+            [ ${#value} -le "$max_len" ] && {
+              printf '%s' "$value"
+              return 0
+            }
+            hash=$(printf '%s' "$value" | sha1sum | cut -c1-4)
+            head_len=$((max_len - 5))
+            printf '%s-%s' "${value:0:${head_len}}" "$hash"
+          }
+
+          branch_preview_name() {
+            project_name="$1"
+            ref_name="$2"
+
+            base="${project_name%-ubq-fi}"
+            if [ "$project_name" = "ubq-fi" ]; then
+              base="ubq"
+            fi
+
+            branch_slug="$(slugify "$ref_name")"
+            base_slug="$(slugify "$base")"
+            [ -n "$branch_slug" ] || branch_slug="preview"
+            [ -n "$base_slug" ] || base_slug="ubq"
+
+            suffix="-ubq-fi"
+            available=$((26 - ${#suffix}))
+            separator_len=1
+            min_branch_len=6
+            min_base_len=6
+
+            branch_len=${#branch_slug}
+            base_len=${#base_slug}
+            if [ $((branch_len + separator_len + base_len)) -gt "$available" ]; then
+              base_budget=$((available - separator_len - min_branch_len))
+              if [ "$base_budget" -lt "$min_base_len" ]; then
+                base_budget="$min_base_len"
+              fi
+              if [ "$base_budget" -gt "$base_len" ]; then
+                base_budget="$base_len"
+              fi
+
+              branch_budget=$((available - separator_len - base_budget))
+              if [ "$branch_budget" -lt "$min_branch_len" ]; then
+                branch_budget="$min_branch_len"
+                base_budget=$((available - separator_len - branch_budget))
+              fi
+
+              base_slug="$(shorten_slug "$base_slug" "$base_budget")"
+              branch_slug="$(shorten_slug "$branch_slug" "$branch_budget")"
+            fi
+
+            printf '%s-%s-ubq-fi\n' "$branch_slug" "$base_slug"
+          }
+
           project="${PROJECT:-}"
           if [ "$project" != "ubq-fi" ] && [[ "$project" != *-ubq-fi ]]; then
             echo "::error::Project name must be 'ubq-fi' or end with '-ubq-fi' to match router mapping. Got: $project"
@@ -533,8 +603,36 @@ jobs:
           fi
 
           preview="${PREVIEW_PROJECT:-}"
+          preview_strategy="${PREVIEW_STRATEGY:-branch}"
+          branch_preview=false
+          case "$preview_strategy" in
+            branch|shared) ;;
+            *)
+              echo "::error::preview_strategy must be 'branch' or 'shared'. Got: $preview_strategy"
+              exit 1
+              ;;
+          esac
+
+          ref_name="${REF_NAME:-}"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REF" ]; then
+            ref_name="$HEAD_REF"
+          fi
+          if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
+            ref_name="$HEAD_BRANCH"
+          fi
+
+          mode="preview"
+          if [ "$EVENT_NAME" = "workflow_run" ] && [ "$WORKFLOW_EVENT" = "pull_request" ]; then
+            :
+          elif [ "$ref_name" = "$PROD_BRANCH" ]; then
+            mode="production"
+          fi
+
           if [ -z "$preview" ]; then
-            if [ "$project" = "ubq-fi" ]; then
+            if [ "$preview_strategy" = "branch" ] && [ "$mode" = "preview" ]; then
+              preview="$(branch_preview_name "$project" "$ref_name")"
+              branch_preview=true
+            elif [ "$project" = "ubq-fi" ]; then
               preview="p-ubq-fi"
             else
               base="${project%-ubq-fi}"
@@ -557,24 +655,26 @@ jobs:
             exit 1
           fi
 
-          ref_name="${REF_NAME:-}"
-          if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$HEAD_BRANCH" ]; then
-            ref_name="$HEAD_BRANCH"
-          fi
-
-          mode="preview"
           target="$preview"
-          if [ "$EVENT_NAME" = "workflow_run" ] && [ "$WORKFLOW_EVENT" = "pull_request" ]; then
-            :
-          elif [ "$ref_name" = "$PROD_BRANCH" ]; then
-            mode="production"
+          router_host=""
+          if [ "$mode" = "production" ]; then
             target="$project"
+            if [ "$project" = "ubq-fi" ]; then
+              router_host="ubq.fi"
+            else
+              router_host="${project%-ubq-fi}.ubq.fi"
+            fi
+          elif [ "$branch_preview" = "true" ]; then
+            router_host="${preview%-ubq-fi}.ubq.fi"
+          elif [ "$project" != "ubq-fi" ]; then
+            router_host="preview-${project%-ubq-fi}.ubq.fi"
           fi
 
           {
             echo "mode=$mode"
             echo "project=$target"
             echo "preview_project=$preview"
+            echo "router_host=$router_host"
           } >> "$GITHUB_OUTPUT"
 
       - name: Export build env
@@ -1467,6 +1567,7 @@ jobs:
           MODE: ${{ steps.deploy.outputs.mode }}
           TARGET_PROJECT: ${{ steps.deploy.outputs.project }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url || '' }}
+          ROUTER_HOST: ${{ steps.target.outputs.router_host || '' }}
         run: |
           set -euo pipefail
           mode="${MODE:-}"
@@ -1481,20 +1582,30 @@ jobs:
           fi
           router_url=""
 
-          base=""
-          if [ "$prod_project" = "ubq-fi" ]; then
-            if [ "$mode" = "production" ]; then
-              router_url="https://ubq.fi"
+          if [ -n "${ROUTER_HOST:-}" ]; then
+            router_url="https://${ROUTER_HOST}"
+          else
+            base=""
+            if [ "$prod_project" = "ubq-fi" ]; then
+              if [ "$mode" = "production" ]; then
+                router_url="https://ubq.fi"
+              fi
+            elif [[ "$prod_project" == *-ubq-fi ]]; then
+              base="${prod_project%-ubq-fi}"
             fi
-          elif [[ "$prod_project" == *-ubq-fi ]]; then
-            base="${prod_project%-ubq-fi}"
+
+            if [ -n "$base" ]; then
+              if [ "$mode" = "production" ]; then
+                router_url="https://${base}.ubq.fi"
+              else
+                router_url="https://preview-${base}.ubq.fi"
+              fi
+            fi
           fi
 
-          if [ -n "$base" ]; then
+          if [ -z "$router_url" ] && [ -n "$prod_project" ] && [ "$mode" = "production" ]; then
             if [ "$mode" = "production" ]; then
-              router_url="https://${base}.ubq.fi"
-            else
-              router_url="https://preview-${base}.ubq.fi"
+              router_url="https://${prod_project}.deno.dev"
             fi
           fi
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides a standardized, reusable Deno Deploy workflow at `.gith
 - Supports new Deno Deploy (`deno deploy`, `.deno.net`) via `deploy_platform: deno2`; Deploy Classic (`deployctl`, `.deno.dev`) remains the default during migration.
 - Optional Node.js and Bun setup for builds (uses official install scripts).
 - Configurable install/build commands (multi-line supported).
-- Branch-aware deployments: production on specified branch (default: `development`), preview on others.
+- Branch-aware deployments: production on specified branch (default: `development`), branch-scoped preview projects on others.
 - Automatic preview project creation if missing.
 - Optional project existence check. `project_secrets` are forwarded as runtime env for the deploy (Deno Deploy secrets API is no longer supported).
 - Gitignore-based excludes with custom includes for build outputs.
@@ -67,6 +67,42 @@ Notes:
 - `forward_all_secrets: true` (opt-in) forwards all available GitHub secrets as runtime env vars; defaults exclude `DENO_DEPLOY_TOKEN` and `GITHUB_TOKEN`.
 - In Deno 2 mode, quota GC is enabled by default only after app creation fails with an app quota/limit error. It deletes one generated preview/branch app, then retries creation once. Production apps, the current target app, and explicitly protected apps are never deleted.
 - Secrets managed in GitHub UI—update secret, next deploy forwards it.
+
+### Branch preview projects
+
+Preview deployments use branch-scoped project names by default:
+
+- Branch `feat/widget` for project `pay-ubq-fi` deploys to `feat-widget-pay-ubq-fi`.
+- The router URL becomes `https://feat-widget-pay.ubq.fi`.
+- Long branch or base names are shortened with a short hash so the project name stays within Deno Deploy's 26-character limit while still remaining branch-specific.
+
+Set `preview_strategy: shared` to keep the legacy shared preview project:
+
+```yaml
+with:
+  project: pay-ubq-fi
+  preview_strategy: shared
+```
+
+To clean up branch preview projects when a branch is deleted, add a delete-triggered workflow in the consumer repo:
+
+```yaml
+name: Deno Deploy Preview Cleanup
+
+on:
+  delete:
+
+jobs:
+  cleanup:
+    if: ${{ github.event.ref_type == 'branch' }}
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-preview-cleanup.yml@main
+    with:
+      project: pay-ubq-fi
+      ref_name: ${{ github.event.ref }}
+      prod_branch: development
+    secrets:
+      DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+```
 
 ### Deno 2 Quota GC
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Notes:
   The workflow creates the app with `deno deploy create`, syncs build/runtime env with `deno deploy env load`, deploys with `deno deploy`, and emits `.deno.net` URLs.
 - Use `project_secrets` to forward env vars to the deployment (`SECRET_NAME=ENV_VAR` per line). In Deno 2 mode these are synced as app env before deployment; in Deploy Classic they are forwarded for the current deploy only.
 - Org-level secrets (`SUPABASE_URL`, `SUPABASE_ANON_KEY`) are shared; no repo-specific copies needed.
-- Customize `include` for build output dirs (e.g., `static/dist/**`).
+- Customize `include` for build output dirs (e.g., `static/**` when `index.html` lives under `static/`).
 - Set `bun_version`/`node_version` and commands for repos with builds. If you use Bun, prefer `bun_version: 1.3.x` (latest as of Dec 2025) instead of older 1.2.x pins.
 - To opt out of PR comments, set `comment_pr: false` in `with:`.
 - `forward_all_secrets: true` (opt-in) forwards all available GitHub secrets as runtime env vars; defaults exclude `DENO_DEPLOY_TOKEN` and `GITHUB_TOKEN`.

--- a/scripts/test-preview-names.sh
+++ b/scripts/test-preview-names.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
+}
+
+shorten_slug() {
+  value="$1"
+  max_len="$2"
+  [ ${#value} -le "$max_len" ] && {
+    printf '%s' "$value"
+    return 0
+  }
+  hash=$(printf '%s' "$value" | sha1sum | cut -c1-4)
+  head_len=$((max_len - 5))
+  printf '%s-%s' "${value:0:${head_len}}" "$hash"
+}
+
+branch_preview_name() {
+  project_name="$1"
+  ref_name="$2"
+
+  base="${project_name%-ubq-fi}"
+  if [ "$project_name" = "ubq-fi" ]; then
+    base="ubq"
+  fi
+
+  branch_slug="$(slugify "$ref_name")"
+  base_slug="$(slugify "$base")"
+  [ -n "$branch_slug" ] || branch_slug="preview"
+  [ -n "$base_slug" ] || base_slug="ubq"
+
+  suffix="-ubq-fi"
+  available=$((26 - ${#suffix}))
+  separator_len=1
+  min_branch_len=6
+  min_base_len=6
+
+  branch_len=${#branch_slug}
+  base_len=${#base_slug}
+  if [ $((branch_len + separator_len + base_len)) -gt "$available" ]; then
+    base_budget=$((available - separator_len - min_branch_len))
+    if [ "$base_budget" -lt "$min_base_len" ]; then
+      base_budget="$min_base_len"
+    fi
+    if [ "$base_budget" -gt "$base_len" ]; then
+      base_budget="$base_len"
+    fi
+
+    branch_budget=$((available - separator_len - base_budget))
+    if [ "$branch_budget" -lt "$min_branch_len" ]; then
+      branch_budget="$min_branch_len"
+      base_budget=$((available - separator_len - branch_budget))
+    fi
+
+    base_slug="$(shorten_slug "$base_slug" "$base_budget")"
+    branch_slug="$(shorten_slug "$branch_slug" "$branch_budget")"
+  fi
+
+  printf '%s-%s-ubq-fi\n' "$branch_slug" "$base_slug"
+}
+
+assert_eq() {
+  expected="$1"
+  actual="$2"
+  label="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "not ok - ${label}: expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_valid_project() {
+  value="$1"
+  label="$2"
+  if [ ${#value} -gt 26 ]; then
+    echo "not ok - ${label}: '${value}' is longer than 26 chars" >&2
+    exit 1
+  fi
+  if ! [[ "$value" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+    echo "not ok - ${label}: '${value}' is not DNS-safe" >&2
+    exit 1
+  fi
+}
+
+pay_preview="$(branch_preview_name pay-ubq-fi feat/widget)"
+assert_eq "feat-widget-pay-ubq-fi" "$pay_preview" "short branch preview"
+assert_valid_project "$pay_preview" "short branch preview"
+
+first_notifications="$(branch_preview_name notifications-ubq-fi feat/a)"
+second_notifications="$(branch_preview_name notifications-ubq-fi fix/b)"
+assert_valid_project "$first_notifications" "long base branch preview"
+assert_valid_project "$second_notifications" "second long base branch preview"
+if [ "$first_notifications" = "$second_notifications" ]; then
+  echo "not ok - long base branches collapsed to the same project" >&2
+  exit 1
+fi
+case "$first_notifications" in
+  p-*|preview-*)
+    echo "not ok - long base branch preview fell back to shared naming: ${first_notifications}" >&2
+    exit 1
+    ;;
+esac
+
+long_branch="$(branch_preview_name pay-ubq-fi feature/some-large-ui-change)"
+assert_valid_project "$long_branch" "long branch preview"
+
+empty_slug="$(branch_preview_name pay-ubq-fi '---')"
+assert_eq "preview-pay-ubq-fi" "$empty_slug" "empty branch slug fallback"
+
+echo "Preview naming tests passed"

--- a/scripts/test-preview-names.sh
+++ b/scripts/test-preview-names.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+## Normalize a branch or project segment into a DNS-safe slug.
 slugify() {
   printf '%s' "$1" \
     | tr '[:upper:]' '[:lower:]' \
     | sed -E 's#[^a-z0-9]+#-#g; s#-+#-#g; s#^-+##; s#-+$##'
 }
 
+## Shorten an already-normalized slug while keeping a stable hash suffix.
 shorten_slug() {
   value="$1"
   max_len="$2"
@@ -19,6 +21,7 @@ shorten_slug() {
   printf '%s-%s' "${value:0:${head_len}}" "$hash"
 }
 
+## Build the Deno Deploy preview project name for a branch and base project.
 branch_preview_name() {
   project_name="$1"
   ref_name="$2"
@@ -63,6 +66,7 @@ branch_preview_name() {
   printf '%s-%s-ubq-fi\n' "$branch_slug" "$base_slug"
 }
 
+## Assert that two strings match and print a TAP-style failure on mismatch.
 assert_eq() {
   expected="$1"
   actual="$2"
@@ -73,6 +77,7 @@ assert_eq() {
   fi
 }
 
+## Assert that a generated Deno Deploy project name satisfies platform limits.
 assert_valid_project() {
   value="$1"
   label="$2"


### PR DESCRIPTION
## Summary
- Derive preview project names from branch refs so non-default branches can get isolated preview deployments.
- Add a cleanup workflow for branch preview projects.
- Document branch preview behavior and add a shell smoke test for preview-name generation.
- Address review feedback by documenting the shell helper functions and clarifying the static include example.

## Validation
- `./scripts/test-preview-names.sh`
- `./scripts/lint-actions.sh`
- `git diff --check`

Fixes #7
/claim #7
